### PR TITLE
Update package.json to make node-osascript only 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 
   "dependencies": {
     "debug": "^2.2.0",
-    "node-osascript": "^1.0.2",
+    "node-osascript": "1.0.2",
     "applescript": "^1.0.0"
   },
   "author": "S'pht'Kr <fthasphtkr@gmail.com> (https://github.com/SphtKr)",


### PR DESCRIPTION
I ran in to lots of homebridge 'hanging' once I added homebridge-itunes.  Removing the plugin always fixed it.  I tried downgrading from node 6 to node-4lts but that did not solve the problem.  The discussion around #6 made me think dependencies might be the problem so I looked at the version histories on homebridge-itunes and low and behold in May a new version of node-osascript came out (first update in several years).  Reverting node-osascript to 1.0.2 fixed things immediately.

Fixes #6 and Fixes #5 (I believe)
